### PR TITLE
Fix "inserting new parameters" error (changed in ansible 1.6.7)

### DIFF
--- a/provisioning/roles/yii-advanced-project/tasks/main.yml
+++ b/provisioning/roles/yii-advanced-project/tasks/main.yml
@@ -8,8 +8,8 @@
   shell: yes | /var/www/yii2-app-advanced/init --env=Development
 
 - name: set Local config with correct MySQL connection etc.
-  template: "{{ item }} owner=vagrant mode=0644"
+  template: "src={{item.src}} dest={{item.dest}} owner=vagrant mode=0644"
   with_items:
-   - src=common-main-local.php dest=/var/www/yii2-app-advanced/common/config/main-local.php
-   - src=frontend-main-local.php dest=/var/www/yii2-app-advanced/frontend/config/main-local.php
-   - src=backend-main-local.php dest=/var/www/yii2-app-advanced/backend/config/main-local.php
+   - { src: 'common-main-local.php', dest: '/var/www/yii2-app-advanced/common/config/main-local.php' }
+   - { src: 'frontend-main-local.php', dest: '/var/www/yii2-app-advanced/frontend/config/main-local.php' }
+   - { src: 'backend-main-local.php', dest: '/var/www/yii2-app-advanced/backend/config/main-local.php' }


### PR DESCRIPTION
ansible does not allow inserting command parameters from a variable anymore, see:

ansible/ansible#8260
